### PR TITLE
길태은 / 3월 3주차 / 9문제 

### DIFF
--- a/Mar/3week/TaeEun/boj_10999.py
+++ b/Mar/3week/TaeEun/boj_10999.py
@@ -1,0 +1,169 @@
+class SegmentTreeBottomUp:
+    def __init__(self, leaf_nodes):
+        self.n = len(leaf_nodes)
+        self.tree = [0]*(2*self.n)
+        self.tree[self.n:] = leaf_nodes[:]
+        self.build()
+        # 전파를 누적해서 저장할 예정
+        self.lazy = [0]*(2*self.n)
+        # 각 노드가 담당하는 구간의 길이를 저장
+        self.seg_len = [0]*(2*self.n)
+        self.seg_len[self.n:] = [1]*self.n
+        for i in range(self.n-1, 0, -1):
+            self.seg_len[i] = self.seg_len[2*i] + self.seg_len[2*i+1]
+    
+    def plus(self, a, b):
+        return a+b
+    
+    def build(self):
+        for i in range(self.n-1, 0, -1):
+            self.tree[i] = self.plus(self.tree[2*i], self.tree[2*i+1])
+
+    def _push(self, idx):
+        """
+        lazy[idx]를 자식에게 전파(push down)하고, idx의 lazy는 비운다.
+        (idx가 리프면 아무 일도 안 함)
+        """
+        if self.lazy[idx] != 0:
+            # 왼쪽 자식
+            lch = idx * 2
+            self.lazy[lch] += self.lazy[idx]
+            self.tree[lch] += self.lazy[idx] * self.seg_len[lch]
+            
+            # 오른쪽 자식
+            rch = lch + 1
+            self.lazy[rch] += self.lazy[idx]
+            self.tree[rch] += self.lazy[idx] * self.seg_len[rch]
+            
+            # 본인 lazy는 0으로
+            self.lazy[idx] = 0
+
+    def _pull(self, idx):
+        """
+        자식의 tree 값을 합쳐서 idx의 tree를 갱신
+        (lazy[idx]도 고려해야 하지만, 이미 자식으로부터 tree 값이 반영된 뒤라
+         여기서는 단순 합으로도 일관성 유지)
+        """
+        self.tree[idx] = self.plus(
+            self.tree[idx * 2],
+            self.tree[idx * 2 + 1]
+        ) + self.lazy[idx] * self.seg_len[idx]
+
+    def _push_path(self, x):
+        """
+        루트(1)에서 x로 가는 경로 상에 있는 노드들을
+        위에서부터 순서대로 push(전파)한다.
+
+        => x가 리프 인덱스(>= n)일 수도 있지만, 내부 인덱스(< n)일 수도 있다.
+           경로에 존재하는 모든 부모 노드를 윗단부터 push해서 
+           최종적으로 x의 조상들이 미룬 lazy가 전부 아래로 내려가도록 한다.
+        """
+        path = []
+        cur = x // 2
+        while cur > 0:
+            path.append(cur)
+            cur //= 2
+        
+        # 루트에서부터 내려오며 push
+        for node in reversed(path):
+            self._push(node)
+
+    def _pull_path(self, x):
+        """
+        x에서 루트(1)까지 올라가며 pull(자식 합)을 갱신.
+        """
+        cur = x // 2
+        while cur > 0:
+            self._pull(cur)
+            cur //= 2
+
+    def update_apply(self):
+        # 루트부터 내부 노드(인덱스 1 ~ n-1)까지 lazy 업데이트를 자식으로 전파
+        for i in range(1, self.n):
+            if self.lazy[i] != 0:
+                # 자식 노드에 lazy 값 누적
+                self.lazy[2*i] += self.lazy[i]
+                self.lazy[2*i+1] += self.lazy[i]
+                # 자식 노드의 tree 값에도 lazy 반영 (구간 길이 만큼 곱해 더함)
+                self.tree[2*i] += self.lazy[i] * self.seg_len[2*i]
+                self.tree[2*i+1] += self.lazy[i] * self.seg_len[2*i+1]
+                self.lazy[i] = 0
+    
+    
+    def update_range(self, left, right, val):
+        """
+        구간 [left, right]에 val을 더한다 (BOJ 10999에서 요구하는 연산)
+        => 바텀업 + lazy (iterative) 방식.
+        """
+        left += self.n
+        right += self.n
+        
+        l0, r0 = left, right
+        
+        # 1) left와 right의 경로에 있는 노드들만 push하여
+        #    현재까지 남아 있던 lazy를 리프 쪽에 미리 반영해둔다.
+        self._push_path(left)
+        self._push_path(right)
+        
+        # 2) [left, right] 범위의 노드들에 업데이트
+        while left <= right:
+            if (left % 2) == 1:   # left가 홀수
+                self.lazy[left] += val
+                self.tree[left] += val * self.seg_len[left]
+                left += 1
+            if (right % 2) == 0: # right가 짝수
+                self.lazy[right] += val
+                self.tree[right] += val * self.seg_len[right]
+                right -= 1
+            left //= 2
+            right //= 2
+        
+        # 3) 업데이트가 끝난 뒤, l0, r0를 부모 방향으로 pull해 
+        #    상위 노드들의 구간합을 다시 갱신
+        self._pull_path(l0)
+        self._pull_path(r0)
+    
+    def query(self, left, right):
+        """
+        구간 [left, right] 합을 구하기.
+        => 쿼리 시에도 부분 경로의 lazy를 push_path로 내려서
+           정확한 값(특히 리프)을 가져오도록 해야 한다.
+        """
+        left += self.n
+        right += self.n
+        
+        # 1) 쿼리 구간 양끝의 경로에 있던 lazy를 자식에게 미리 반영
+        self._push_path(left)
+        self._push_path(right)
+        
+        # 2) 이제 표준적인 바텀업 구간 합 쿼리
+        result = 0
+        while left <= right:
+            if (left % 2) == 1:
+                result = self.plus(result, self.tree[left])
+                left += 1
+            if (right % 2) == 0:
+                result = self.plus(result, self.tree[right])
+                right -= 1
+            left //= 2
+            right //= 2
+        return result
+
+N, M, K = map(int,input().split())
+
+leaf_nodes = []
+for _ in range(N):
+    leaf_nodes.append(int(input()))
+tree = SegmentTreeBottomUp(leaf_nodes)
+
+for _ in range(M+K):
+    order = list(map(int,input().split()))
+    order_num = order[0]
+    # idx화 하려면 -1 해야한다. 번째의 의미
+    start = order[1]-1
+    end = order[2]-1
+    if order_num == 1:
+        d = order[3]
+        tree.update_range(start, end, d)
+    if order_num == 2:
+        print(tree.query(start, end))

--- a/Mar/3week/TaeEun/boj_1325.py
+++ b/Mar/3week/TaeEun/boj_1325.py
@@ -1,0 +1,46 @@
+
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+N, M = map(int,input().split())
+graph = [[] for _ in range(N+1)]
+
+for _ in range(M):
+    end, start = map(int,input().split())
+    graph[start].append(end)
+
+def bfs(node):
+    q = deque()
+    q.append(node)
+    visited = [False] *(N+1)
+    visited[node] = True
+    cnt = 1
+    
+    while q:
+        cur_node = q.popleft()
+        for next_node in graph[cur_node]:
+            if visited[next_node]:
+                continue
+            q.append(next_node)
+            visited[next_node] = True
+            cnt += 1
+    return cnt
+
+max_cnt = 0
+max_list = []
+
+for i in range(1, 1+N):
+    if graph[i] == []:
+        cnt = 1
+    else:
+        cnt = bfs(i)
+    
+    if max_cnt < cnt:
+        max_cnt = cnt
+        max_list = [i]
+    elif max_cnt == cnt:
+        max_list.append(i)
+        
+print(*max_list)

--- a/Mar/3week/TaeEun/boj_1339.py
+++ b/Mar/3week/TaeEun/boj_1339.py
@@ -1,0 +1,84 @@
+from heapq import heappop, heappush
+
+N = int(input())
+words = [0]*N
+priority = {}
+
+
+for i in range(N):
+    word = input()
+    words[i] = word
+    max_digit = len(word)-1
+    
+    for digit_num in range(max_digit+1):
+        digit_idx = max_digit-digit_num  # 인덱스는 거꾸로다!
+        alphabet = word[digit_idx]
+        if not priority.get(alphabet):
+            priority[alphabet] = 0
+        priority[alphabet] += 10**(digit_num)
+    
+heap = []
+
+for item in priority.items():
+    alpha, prior = item
+    heappush(heap, (-prior, alpha))
+
+alphabet_to_num = {}
+for i in range(9, -1, -1):
+    if heap == []:
+        break
+    prior, alpha = heappop(heap)
+    alphabet_to_num[alpha] = str(i)
+
+ans = 0
+
+for word in words:
+    result = ''
+    for i in range(len(word)):
+        result += alphabet_to_num[word[i]]
+    ans += int(result)
+    
+print(ans)
+
+
+# def main():
+#     import sys
+#     input = sys.stdin.readline
+#     n = int(input().strip())
+#     letter_weight = {}
+    
+#     # 각 글자가 가지는 자릿수 가중치 계산
+#     for _ in range(n):
+#         word = input().strip()
+#         length = len(word)
+#         for i, char in enumerate(word):
+#             # 해당 글자의 자릿수에 따른 기여도 (10^(위치))
+#             letter_weight[char] = letter_weight.get(char, 0) + 10 ** (length - i - 1)
+    
+#     # 기여도가 큰 글자부터 높은 숫자를 할당
+#     sorted_letters = sorted(letter_weight.items(), key=lambda x: x[1], reverse=True)
+#     result = 0
+#     current_digit = 9
+#     for letter, weight in sorted_letters:
+#         result += current_digit * weight
+#         current_digit -= 1
+    
+#     print(result)
+
+# if __name__ == '__main__':
+#     main()
+
+
+# 가중치 딕셔너리 제작
+# items로 힙 푸시 해서 정렬 
+# 뽑으면서 0~9 사전 제작 
+# 단어 읽으면서 숫자 제작
+
+# gpt에서 얻은 것
+# letter_weight[char] = letter_weight.get(char, 0) + 10 ** (length - i - 1)
+# 한 줄로 없으면 초기화까지 구현
+# sorted_letters = sorted(letter_weight.items(), key=lambda x: x[1], reverse=True)
+# 한 줄로 정렬을 위한 교환 없이 정렬. 
+# 키를 lambda x: x[1], 로 키순서대로 정렬해라
+# reverse = True로 큰 순서대로 정렬
+

--- a/Mar/3week/TaeEun/boj_14891.py
+++ b/Mar/3week/TaeEun/boj_14891.py
@@ -1,0 +1,125 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+
+N = 4  # 기어 수
+M = 8  # 기어 날개 수
+gears = [0]*N
+pointors = [[0,2,6] for _ in range(N)]
+twelve = 0
+right = 1
+left = 2
+
+def rotate(gear_idx, rotation):
+
+    if rotation == 1:
+        rotate_num = 7
+    else:
+        rotate_num = 1
+
+    for i in range(3):
+        pointors[gear_idx][i] += rotate_num
+        pointors[gear_idx][i] %= M
+
+for i in range(N):
+    gears[i] = input()
+
+# print(gears)
+
+K = int(input())
+
+q = []
+
+for _ in range(K):
+    gear_no, rotation = map(int, input().split())
+    gear_idx = gear_no - 1
+    
+    will_be_rotated =[0]*N
+    
+    visited = [False]*N
+    q.append((gear_idx, rotation))
+    visited[gear_idx] = True
+    
+    while q:
+        cur_idx, cur_rotation = q.pop(0)
+        # print(cur_idx)
+        will_be_rotated[cur_idx] = cur_rotation
+        left_idx = cur_idx -1
+        right_idx = cur_idx + 1
+        if left_idx >=0 and not visited[left_idx]:
+            # print('left not visited')
+            # print('idx',cur_idx, left_idx)
+            # print('pointors', pointors[cur_idx][left], pointors[left_idx][right])
+            # print(gears[cur_idx][pointors[cur_idx][left]], gears[left_idx][pointors[left_idx][right]])
+            if gears[cur_idx][pointors[cur_idx][left]] != gears[left_idx][pointors[left_idx][right]]:
+                q.append((left_idx, cur_rotation*(-1)))
+                visited[left_idx] = True
+
+        
+        if right_idx < N and not visited[right_idx]:
+            # print('right not visited')
+            # print('idx',cur_idx, right_idx)
+            # print('pointors', pointors[cur_idx][right], pointors[right_idx][left])
+            # print(gears[cur_idx][pointors[cur_idx][right]], gears[right_idx][pointors[right_idx][left]])
+            if gears[cur_idx][pointors[cur_idx][right]] != gears[right_idx][pointors[right_idx][left]]:
+                q.append((right_idx, cur_rotation*(-1)))
+                visited[right_idx] = True
+    
+    # print(will_be_rotated)
+    
+    for gear_idx in range(4):
+        if will_be_rotated[gear_idx] == 0:
+            continue
+        rotate(gear_idx, will_be_rotated[gear_idx])
+
+
+ans = 0
+
+for gear_i in range(N):
+    ans += int(gears[gear_i][pointors[gear_i][twelve]]) *(1<<gear_i)
+
+print(ans)
+
+
+
+# GPT 예시
+
+# from collections import deque
+# def main():
+#     # 톱니바퀴 4개의 초기 상태를 입력받아 deque에 저장
+#     gears = [deque(input().strip()) for _ in range(4)]
+#     K = int(input().strip())  # 회전 명령의 개수
+#     for _ in range(K):
+#         idx, direction = map(int, input().split())
+#         idx -= 1  # 0-index로 변환
+#         # 각 톱니바퀴가 회전할 방향을 저장하는 리스트 (0이면 회전 없음)
+#         rotate_directions = [0] * 4
+#         rotate_directions[idx] = direction
+#         # 왼쪽 톱니바퀴로 전파
+#         for i in range(idx, 0, -1):
+#             if gears[i][6] != gears[i-1][2]:
+#                 rotate_directions[i-1] = -rotate_directions[i]
+#             else:
+#                 break  # 접촉부가 같으면 연쇄 전파 중단
+#         # 오른쪽 톱니바퀴로 전파
+#         for i in range(idx, 3):
+#             if gears[i][2] != gears[i+1][6]:
+#                 rotate_directions[i+1] = -rotate_directions[i]
+#             else:
+#                 break
+#         # 모든 톱니바퀴에 대해 회전 적용
+#         for i in range(4):
+#             if rotate_directions[i] != 0:
+#                 gears[i].rotate(rotate_directions[i])
+#     # 최종 점수 계산
+#     score = 0
+#     for i in range(4):
+#         if gears[i][0] == '1':
+#             score += (1 << i)
+#     print(score)
+# if __name__ == '__main__':
+#     main()
+
+
+# 여기서 배운 것 deque.rotate()가 회전을 의미한다.
+# 어떤 d = deque(리스트) 일 때 
+# d.rotate(2) = 오른쪽으로 2칸 이동, d.rotate(-1) = 왼쪽으로 1칸 이동

--- a/Mar/3week/TaeEun/boj_17472.py
+++ b/Mar/3week/TaeEun/boj_17472.py
@@ -1,0 +1,104 @@
+from collections import deque
+from heapq import heappop, heappush
+
+
+N, M = map(int,input().split())
+islands = [list(map(int,input().split())) for _ in range(N)]
+
+directions = [(1,0), (-1,0), (0, 1), (0, -1)]
+
+def labelling(r,c,i):
+    q = deque()
+    q.append((r,c))
+    visited[r][c] = True
+    
+    while q:
+        cur_r, cur_c = q.popleft()
+        islands[cur_r][cur_c] = i
+        for dr, dc in directions:
+            new_r, new_c = cur_r + dr, cur_c + dc
+            if 0<= new_r<N and 0<= new_c <M:
+                if visited[new_r][new_c] or islands[new_r][new_c] == 0:
+                    continue
+                q.append((new_r, new_c))
+                visited[new_r][new_c] = True
+
+adj_dict = [0]
+label = 1
+visited = [[False]*M for _ in range(N)]
+for r in range(N):
+    for c in range(M):
+        if islands[r][c] == 1 and not visited[r][c]:
+            labelling(r,c,label)
+            adj_dict.append({})
+            label += 1
+
+
+for r in range(N):
+    start_island = 0
+    zero_count = 0
+    for c in range(M):
+        cur_no = islands[r][c]
+        if cur_no == 0:
+            zero_count += 1
+        else:
+            if start_island !=0 and cur_no != start_island and zero_count > 1:
+                if adj_dict[start_island].get(cur_no):
+                    if adj_dict[start_island][cur_no] > zero_count:
+                        adj_dict[start_island][cur_no] = zero_count
+                        adj_dict[cur_no][start_island] = zero_count
+                else:
+                    adj_dict[start_island][cur_no] = zero_count
+                    adj_dict[cur_no][start_island] = zero_count
+            start_island = cur_no
+            zero_count = 0
+
+
+for c in range(M):
+    start_island = 0
+    zero_count = 0
+    for r in range(N):
+        cur_no = islands[r][c]
+        if cur_no == 0:
+            zero_count += 1
+        else:
+            if start_island !=0 and cur_no != start_island and zero_count > 1:
+                if adj_dict[start_island].get(cur_no):
+                    if adj_dict[start_island][cur_no] > zero_count:
+                        adj_dict[start_island][cur_no] = zero_count
+                        adj_dict[cur_no][start_island] = zero_count
+                else:
+                    adj_dict[start_island][cur_no] = zero_count
+                    adj_dict[cur_no][start_island] = zero_count
+            start_island = cur_no
+            zero_count = 0
+
+
+def prim(cost, node):
+    pq = []
+    heappush(pq, (cost, node))
+    visited = [False]*len(adj_dict)
+    min_cost = 0
+    connected_count = 0
+    
+    while pq:
+        cur_cost, cur_node = heappop(pq)
+        
+        if visited[cur_node]:
+            continue
+        
+        visited[cur_node] = 1
+        min_cost = min_cost + cur_cost
+        connected_count += 1
+        
+        for next_node, next_cost in adj_dict[cur_node].items():
+            if visited[next_node]:
+                continue
+            heappush(pq, (next_cost, next_node))
+    
+    if connected_count != label -1:
+        return -1
+    
+    return min_cost
+            
+print(prim(0, 1))

--- a/Mar/3week/TaeEun/boj_2042.py
+++ b/Mar/3week/TaeEun/boj_2042.py
@@ -1,0 +1,53 @@
+class SegmentTreeBottomUp:
+    def __init__(self, leaf_nodes):
+        self.n = len(leaf_nodes)
+        self.tree = [0]*(2*self.n)
+        self.tree[self.n:] = leaf_nodes[:]
+        self.build()
+    
+    def plus(self, a, b):
+        return a+b
+    
+    def build(self):
+        for i in range(self.n-1, 0, -1):
+            self.tree[i] = self.plus(self.tree[2*i], self.tree[2*i+1])
+    
+    
+    def query(self, left, right):
+        left += self.n
+        right += self.n
+        # 트리의 인덱스로 변형
+        result = 0
+        while left <= right:
+            if left % 2 == 1:
+                result = self.plus(result, self.tree[left])
+                left +=1
+            if right % 2 == 0:
+                result = self.plus(result, self.tree[right])
+                right -= 1
+            left //= 2
+            right //= 2
+        return result
+
+    def update(self, idx, val):
+        i = self.n +idx
+        self.tree[i] = val
+        while i >= 1:
+            i = i //2
+            self.tree[i] = self.plus(self.tree[i*2], self.tree[i*2+1])
+
+
+
+N, M, K = map(int,input().split())
+
+leaf_nodes = []
+for _ in range(N):
+    leaf_nodes.append(int(input()))
+tree = SegmentTreeBottomUp(leaf_nodes)
+
+for _ in range(M+K):
+    a, b, c = map(int,input().split())
+    if a == 1:
+        tree.update(b-1, c) 
+    if a == 2:
+        print(tree.query(b-1, c-1))

--- a/Mar/3week/TaeEun/boj_2146.py
+++ b/Mar/3week/TaeEun/boj_2146.py
@@ -1,0 +1,75 @@
+from collections import deque
+from pprint import pprint
+
+N = int(input())
+islands = [list(map(int,input().split())) for _ in range(N)]
+
+directions = [(1,0), (-1,0), (0,1), (0,-1)]
+
+islands_borders = []
+
+def make_border_set(r,c,i):
+    q = deque()
+    q.append((r,c))
+    visited[r][c] = True
+    
+    while q:
+        cur_r, cur_c = q.popleft()
+        islands[cur_r][cur_c] = i
+        for dr, dc in directions:
+            new_r, new_c = cur_r + dr, cur_c + dc
+            if 0<= new_r<N and 0<= new_c <N:
+                if visited[new_r][new_c]:
+                    continue
+                if islands[new_r][new_c] == 0:
+                    if (cur_r, cur_c) not in border_set:
+                        border_set.add((cur_r, cur_c))
+                    continue
+                q.append((new_r, new_c))
+                visited[new_r][new_c] = True
+    
+def min_bridge_length(r,c, i):
+    q = deque()
+    visited = [[False]*N for _ in range(N)]
+    step = 0
+    q.append((r,c,step))
+    visited[r][c] = True
+    
+    while q:
+        cur_r, cur_c, cur_steps = q.popleft()
+        for dr, dc in directions:
+            new_r, new_c = cur_r + dr, cur_c + dc
+            if 0<= new_r<N and 0<= new_c <N:
+                if visited[new_r][new_c] or islands[new_r][new_c] == i:
+                    continue
+                if islands[new_r][new_c] != 0:
+                    return cur_steps
+                new_steps = cur_steps+1
+                if new_steps >= ans:
+                    continue
+                q.append((new_r,new_c, new_steps))
+                visited[new_r][new_c] = True
+    return N**2
+    
+
+visited = [[False]*N for _ in range(N)]
+island_number = 1
+for r in range(N):
+    for c in range(N):
+        if visited[r][c] or islands[r][c] == 0:
+            continue
+        border_set = set()
+        make_border_set(r,c,island_number)
+        islands_borders.append(border_set)
+        island_number += 1
+
+
+ans = N**2 # 최대 거리 N*N
+
+for i in range(len(islands_borders)):
+    cur_border_set = islands_borders[i]
+    for border_coord in cur_border_set:
+        r, c = border_coord
+        ans = min(ans, min_bridge_length(r,c,i+1))
+
+print(ans)

--- a/Mar/3week/TaeEun/sea_1249.py
+++ b/Mar/3week/TaeEun/sea_1249.py
@@ -1,0 +1,36 @@
+from heapq import heappop, heappush
+
+directions = [(1,0),(0, 1),(-1,0),(0, -1)]
+
+def dijkstra(node):
+    q = []
+    visited = set()
+    sum_times = 0
+    heappush(q, (sum_times, node))
+    visited.add(node)
+        
+    while q:
+        cur_sum_times, cur_node = heappop(q)
+        cur_r, cur_c = cur_node
+        for dr, dc in directions:
+            new_r, new_c = cur_r + dr, cur_c + dc
+            new_node = (new_r, new_c)
+            if 0<= new_r<N and 0<=new_c<N:
+                if new_node not in visited:
+                    visited.add(new_node)
+                    new_sum_time = ground[new_r][new_c] + cur_sum_times
+                    heappush(q, (new_sum_time, new_node))
+                    if new_node == (N-1, N-1):
+                        return new_sum_time
+
+    return -1
+
+T = int(input())
+
+for tc in range(1,T+1):
+    N = int(input())
+    ground = [list(map(int, list(input()))) for _ in range(N)]
+    ans = 0
+    start = (0,0)
+    ans = dijkstra(start)
+    print(f'#{tc}', ans)

--- a/Mar/3week/TaeEun/sea_1251.py
+++ b/Mar/3week/TaeEun/sea_1251.py
@@ -1,0 +1,37 @@
+from heapq import heappop, heappush
+
+def dijkstra(node):
+    q = []
+    visited = [False] *(N)
+    fee = 0
+    sum_fee = 0
+    heappush(q, (fee, node))
+        
+    while q:
+        cur_fee, cur_node = heappop(q)
+        if not visited[cur_node]:
+            visited[cur_node] = True
+            sum_fee += cur_fee
+            for adj_node in range(N):
+                if adj_node == cur_node or visited[adj_node]:
+                    continue
+                connect_fee = adj_matrix[cur_node][adj_node]
+                heappush(q, (connect_fee, adj_node))
+
+    return sum_fee
+
+T = int(input())
+
+for tc in range(1,T+1):
+    N = int(input())
+    adj_matrix = [[-1]*N for _ in range(N)]
+    x_list = list(map(int, input().split()))
+    y_list = list(map(int, input().split()))
+    E = float(input())
+    for i in range(N):
+        for j in range(i,N):
+            L_square = abs(x_list[i] - x_list[j])**2 + abs(y_list[i]-y_list[j])**2
+            environmental_fee = E*L_square
+            adj_matrix[i][j] = environmental_fee
+            adj_matrix[j][i] = environmental_fee
+    print(f'#{tc}', round(dijkstra(0)))


### PR DESCRIPTION
# TIL 250318

## SEA.1251.하나로

프림 알고리즘 연습을 할 수 있었다.
어렵지 않게 구현 가능했지만
아직 방문 조건 구현이 반대가 되는 이유를 모르겠다

## SEA.1249.보급로

이전에 백트래킹으로 구현했던 걸
다익스트라로 구현했다.
처음에 좀 헤맸는데
차근차근 구현하니 바로 풀 수 있었다.

## BOJ.1325.효율적인 해킹

DP로 구현해보려고 했는데 실패했다.
문제 구조상 사이클이 있을 수 없다고 생각했는데
그런 게 존재하는, 즉 트리 형태로 구성하기 힘든 모양이었던 것 같다.
그래서 헤매다가 정석대로 모든 케이스에서 BFS 돌면서 풀었다.
하지만 더 줄일 수 있을 것 같긴 하다.
한 번 BFS로 계산한 걸 가져다 쓸 수 있을 거 같다.

## BOJ. 14891.톱니바퀴

이 문제를 봤을 때 원본을 바꾸는 게 아닌
포인터를 활용하고 싶었다.
그래서 포인터를 3개 만들어서 써봤는데
너무 어지럽게 표현이 되어서 조금 익숙해져야할 거 같다.
포인터는 반대로 돌아야한다는 것도 하고 나서야 눈치챘다.
또 디버깅이 좀 힘들었다. 

별개로 진짜 로테이션은 deque.rotate(n)으로 구현가능한 걸 알게되었고
또 전파하는 과정이 큐 느낌이 나서 큐를 사용했는데
이정도 크기에선 그냥 for문으로 전파하는 게 맞았던 거 같다.

## BOJ.2146.다리만들기

2가지 함수로 나눠서 
1) 섬 그룹으로 묶어서 바꾸는 bfs + 테두리 그룹 만들기
2) 각 테두리 그룹에서 다른 그룹으로 가는 bfs - 최소 거리 갱신
이렇게 구성했다.
디버깅 했던 부분은 같은 그룹을 만났을 때 탈출하는 부분이었다.

## BOJ.1339.단어수학

가중치가 있는 딕셔너리 제작한 부분과
거꾸로 읽어가면서 0~9 배치하기까진 확실히 생각해냈다.
이후엔 gpt로 복기했는데
키를 기준으로 키순대로 정렬하는 것이 key=lambda x: x[1]로 가능한 것과
letter_weight.get(char, 0)으로 없으면 0 나오게 가능 한 것을 얻었다.

## BOJ.17472.다리 만들기 2

행렬 형태의 맵을 받았을 때
이걸 가중치가 있는 그래프로 다시 변형을 하고
그걸 프림을 통해 MST을 찾아 가중치의 합을 구했다.
핵심이었던 가중치 계산은 행과 열을 돌아서  0이 아니면 0 카운터를 세는 느낌으로 구현했다.

## BOJ.2042.구간 합 구하기

세그먼트 트리를 연습했다.
이 경우 탑-다운 형태가 아니라 바텀-업으로 구성해봤는데
쿼리를 구현하는 게 조금 이해가 안 됐다.
양쪽을 올려서 노드를 찾아가는 과정을 홀짝으로 구현했는데
처음에는 이해가 잘 안 되어서
따로 찾아보고 이해할 수 있었다.

## BOJ.10999.구간 합 구하기2

윗 문제에서 크게 다르지 않다고 생각해서 쉽다고 생각했지만
해당 크기에서는 불가능한 생각이었다.
하나하나를 계속 업데이트 하는 건 시간이 너무 오래 걸렸고
이렇게 동시에 업데이트를 하는 경우에는
전파 또한 변화를 누적해서 동시에 하는 게 맞았다
다만 내가 바텀-업으로 구성했던 코드에서 시작해서 하려고 하니
생각보다 아주 힘들었었다.
그래서 GPT의 도움을 많이 받았다.
탑-다운으로 다시 풀어봐야할 거 같다.