### PR TITLE
길태은 / 3월 4주차 / 7문제 

### DIFF
--- a/Mar/4week/TaeEun/boj_10999.py
+++ b/Mar/4week/TaeEun/boj_10999.py
@@ -1,0 +1,86 @@
+class SegmentTreeBottomUp:
+    def __init__(self, leaf_nodes):
+        self.n = len(leaf_nodes)
+        self.tree = [0]*(4*self.n)
+        self.lazy = [0]*(4*self.n)
+        self.build(1, 0, self.n -1) # 최초의 제작
+    
+    def plus(self, a, b):
+        return a+b
+    
+    def build(self, node, start, end):
+        if start == end:
+            self.tree[node] = leaf_nodes[start]
+            return
+        mid = (start+end) // 2
+        self.build(2*node, start, mid)
+        self.build(2*node+1, mid+1, end)
+        self.tree[node] = self.tree[2*node] + self.tree[2*node+1]
+        
+    def propagate(self, node, start, end):
+        if self.lazy[node]:
+            self.tree[node] += (end - start +1) * self.lazy[node]
+            # lazy가 남아있는 놈은 무조건 해당 구간 전부에 lazy값을 적용 하려는 놈
+            
+            if start != end:
+                self.lazy[2*node] += self.lazy[node]
+                self.lazy[2*node+1] += self.lazy[node]
+            self.lazy[node] = 0
+            
+
+    # start, end 는 해당 노드가 감싸고 있는 구간의 양 끝
+    # left, right 는 우리가 검색을 원하는 구간의 양 끝
+    def query(self, node, start, end, left, right):
+        # 검색 중에 만나면 전파부터 해라(그래야 안 꼬임)
+        self.propagate(node, start, end)
+        
+        # 우리가 찾는 구간의 오른쪽이, 해당 노드의 왼쪽보다 작으면 노해당
+        # 우리가 찾는 구간의 왼쪽이, 해당 노드의 오른쪽보다 크면 노해당
+        if right < start or left > end:
+            return 0
+        
+        # 해당 노드의 범위가 우리가 찾는 범위의 안쪽이면 그 값으로 돌아가라
+        if right >= end and left <= start:
+            return self.tree[node]
+        
+        mid = (start+end) //2
+        
+        return self.query(2*node, start, mid, left, right) + self.query(2*node+1, mid+1, end, left, right)
+
+    def update_range(self, node, start, end, left, right, delta):
+        # 업데이트 하러 가다 보이면 전파부터 해라!
+        self.propagate(node, start, end)
+        
+        if right < start or left >end:
+            return
+        
+        if right >= end and left <= start:
+            self.lazy[node] += delta
+            self.propagate(node, start, end)
+            return
+        
+        mid = (start+end)//2
+        self.update_range(2*node, start, mid, left, right, delta)
+        self.update_range(2*node+1, mid+1,end, left, right, delta)
+        self.tree[node] = self.tree[node*2] + self.tree[node*2+1]
+        return
+
+
+N, M, K = map(int,input().split())
+
+
+leaf_nodes = [int(input()) for _ in range(N)]
+tree = SegmentTreeBottomUp(leaf_nodes)
+
+for _ in range(M+K):
+    order = list(map(int,input().split()))
+    a= order[0]
+    # idx화 하려면 -1 해야한다. 번째의 의미
+    b = order[1]-1
+    c = order[2]-1
+    if a == 1:
+        d = order[3]
+        tree.update_range(1,0,N-1,b,c,d)
+
+    elif a == 2:
+        print(tree.query(1, 0, N-1, b, c))

--- a/Mar/4week/TaeEun/boj_11658.py
+++ b/Mar/4week/TaeEun/boj_11658.py
@@ -1,124 +1,61 @@
-import sys
-input = sys.stdin.readline
+## 1차원 펜윅부터 구현해서 확장함
 
-class SegmentTree2D:
-    def __init__(self, leaf_matrix):
 
-        self.n = len(leaf_matrix) - 1         # 행의 수는 -1
-        self.m = len(leaf_matrix[1]) - 1      # 열의 수도 -1
-        self.leaf_matrix = leaf_matrix
-        # 2차원 세그먼트 트리: 외부 트리 크기는 4*n, 각 내부 트리 크기는 4*m
-        self.tree = [[0]*(4*self.m) for _ in range(4*self.n)]
-        self.build_x(1, 1, self.n)
+class FenwickTree2D:
+    def __init__(self, matrix):
+        self.n = len(matrix)
+        self.tree = [[0] * (self.n+1) for _ in range(self.n+1)]
+        for i in range(1, self.n+1):
+            for j in range(1, self.n+1):
+                self.update(i, j, matrix[i-1][j-1]) # 0based를 1based로 사용해야함
         
-    # 외부 트리(행에 대한) 구축 함수
-    def build_x(self, node_x, start_x, end_x):
-        if start_x == end_x:
-            # 외부 노드가 단일 행을 담당하면 해당 행의 내부 세그먼트 트리를 구축
-            self.build_y(node_x, start_x, 1, 1, self.m)
-        else:
-            mid = (start_x + end_x) // 2
-            self.build_x(2*node_x, start_x, mid)
-            self.build_x(2*node_x+1, mid+1, end_x)
-            # 자식 외부 노드의 내부 트리들을 병합하여 현재 외부 노드의 내부 트리 구축
-            self.build_y_merge(node_x, 1, 1, self.m)
+    def update(self, r, c, delta):
+        i = r
+        while i <= self.n:
+            j = c
+            while j <= self.n:
+                self.tree[i][j] += delta
+                j += j&-j
+            i += i &-i
             
-    # 단일 행(row)에 대한 내부 세그먼트 트리 구축 (리프 외부 노드)
-    def build_y(self, node_x, row, node_y, start_y, end_y):
-        if start_y == end_y:
-            self.tree[node_x][node_y] = self.leaf_matrix[row][start_y]
-        else:
-            mid = (start_y + end_y) // 2
-            self.build_y(node_x, row, 2*node_y, start_y, mid)
-            self.build_y(node_x, row, 2*node_y+1, mid+1, end_y)
-            self.tree[node_x][node_y] = self.tree[node_x][2*node_y] + self.tree[node_x][2*node_y+1]
-            
-    # 내부 트리 병합: 자식 외부 노드(2*node_x, 2*node_x+1)의 내부 트리 정보를 이용하여 내부 트리 구성
-    def build_y_merge(self, node_x, node_y, start_y, end_y):
-        if start_y == end_y:
-            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
-        else:
-            mid = (start_y + end_y) // 2
-            self.build_y_merge(node_x, 2*node_y, start_y, mid)
-            self.build_y_merge(node_x, 2*node_y+1, mid+1, end_y)
-            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
-            
-    # 2차원 쿼리: 행 구간 [x1, x2]와 열 구간 [y1, y2]의 합 구하기
-    def query_x(self, node_x, start_x, end_x, x1, x2, y1, y2):
-        if x2 < start_x or x1 > end_x:
-            return 0
-        if x1 <= start_x and end_x <= x2:
-            return self.query_y(node_x, 1, 1, self.m, y1, y2)
-        mid = (start_x + end_x) // 2
-        return self.query_x(2*node_x, start_x, mid, x1, x2, y1, y2) + \
-               self.query_x(2*node_x+1, mid+1, end_x, x1, x2, y1, y2)
+    def query(self, r, c):
+        res = 0
+        i = r
+        while i > 0:
+            j = c
+            while j> 0:
+                res += self.tree[i][j]
+                j -= j&-j
+            i-= i&-i
+        return res
     
-    def query_y(self, node_x, node_y, start_y, end_y, y1, y2):
-        if y2 < start_y or y1 > end_y:
-            return 0
-        if y1 <= start_y and end_y <= y2:
-            return self.tree[node_x][node_y]
-        mid = (start_y + end_y) // 2
-        return self.query_y(node_x, 2*node_y, start_y, mid, y1, y2) + \
-               self.query_y(node_x, 2*node_y+1, mid+1, end_y, y1, y2)
-    
-    # 2차원 업데이트: (x, y) 위치의 값을 delta만큼 변경(즉, 기존 값에 delta를 더함)
-    def update_x(self, node_x, start_x, end_x, x, y, delta):
-        if x < start_x or x > end_x:
-            return
-        if start_x == end_x:
-            self.update_y(node_x, 1, 1, self.m, y, delta)
-        else:
-            mid = (start_x + end_x) // 2
-            if x <= mid:
-                self.update_x(2*node_x, start_x, mid, x, y, delta)
-            else:
-                self.update_x(2*node_x+1, mid+1, end_x, x, y, delta)
-            # 자식 외부 노드의 내부 트리 값 변경에 따라 현재 노드의 내부 트리도 갱신
-            self.update_y_merge(node_x, 1, 1, self.m, y)
-    
-    def update_y(self, node_x, node_y, start_y, end_y, y, delta):
-        if y < start_y or y > end_y:
-            return
-        if start_y == end_y:
-            self.tree[node_x][node_y] += delta
-        else:
-            mid = (start_y + end_y) // 2
-            if y <= mid:
-                self.update_y(node_x, 2*node_y, start_y, mid, y, delta)
-            else:
-                self.update_y(node_x, 2*node_y+1, mid+1, end_y, y, delta)
-            self.tree[node_x][node_y] = self.tree[node_x][2*node_y] + self.tree[node_x][2*node_y+1]
-    
-    # 내부 트리 병합 업데이트: 내부 노드에서 y에 해당하는 구간만 갱신
-    def update_y_merge(self, node_x, node_y, start_y, end_y, y):
-        if start_y == end_y:
-            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
-        else:
-            mid = (start_y + end_y) // 2
-            if y <= mid:
-                self.update_y_merge(node_x, 2*node_y, start_y, mid, y)
-            else:
-                self.update_y_merge(node_x, 2*node_y+1, mid+1, end_y, y)
-            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
+    def range_query(self, x1, y1, x2, y2):
+        return self.query(x2, y2) - self.query(x2, y1-1) - self.query(x1-1, y2) + self.query(x1-1, y1-1)       
 
 
-N, M = map(int, input().split())
-# 1-based로 바꿈
-leaf_matrix = [[0] + list(map(int, input().split())) for _ in range(N)]
-leaf_matrix = [0] + leaf_matrix
+N, M = map(int,input().split())
 
-tree = SegmentTree2D(leaf_matrix)
+leaf_matrix = [list(map(int,input().split())) for _ in range(N)]
+
+tree = FenwickTree2D(leaf_matrix)
 
 for _ in range(M):
-    order = list(map(int, input().split()))
-    w = order[0]
+    order = list(map(int,input().split()))
+    w= order[0]
     if w == 0:
         x, y, c = order[1], order[2], order[3]
-        # delta = 새 값 - 기존 값
-        delta = c - leaf_matrix[x][y]
-        leaf_matrix[x][y] = c
-        tree.update_x(1, 1, tree.n, x, y, delta)
+        delta = c-leaf_matrix[x-1][y-1]
+        leaf_matrix[x-1][y-1] = c
+        tree.update(x, y, delta)
+
     elif w == 1:
         x1, y1, x2, y2 = order[1], order[2], order[3], order[4]
-        print(tree.query_x(1, 1, tree.n, x1, x2, y1, y2))
+        print(tree.range_query(x1, y1, x2, y2))
+        
+        
+        
+        
+        
+        
+        
+

--- a/Mar/4week/TaeEun/boj_11658.py
+++ b/Mar/4week/TaeEun/boj_11658.py
@@ -1,0 +1,124 @@
+import sys
+input = sys.stdin.readline
+
+class SegmentTree2D:
+    def __init__(self, leaf_matrix):
+
+        self.n = len(leaf_matrix) - 1         # 행의 수는 -1
+        self.m = len(leaf_matrix[1]) - 1      # 열의 수도 -1
+        self.leaf_matrix = leaf_matrix
+        # 2차원 세그먼트 트리: 외부 트리 크기는 4*n, 각 내부 트리 크기는 4*m
+        self.tree = [[0]*(4*self.m) for _ in range(4*self.n)]
+        self.build_x(1, 1, self.n)
+        
+    # 외부 트리(행에 대한) 구축 함수
+    def build_x(self, node_x, start_x, end_x):
+        if start_x == end_x:
+            # 외부 노드가 단일 행을 담당하면 해당 행의 내부 세그먼트 트리를 구축
+            self.build_y(node_x, start_x, 1, 1, self.m)
+        else:
+            mid = (start_x + end_x) // 2
+            self.build_x(2*node_x, start_x, mid)
+            self.build_x(2*node_x+1, mid+1, end_x)
+            # 자식 외부 노드의 내부 트리들을 병합하여 현재 외부 노드의 내부 트리 구축
+            self.build_y_merge(node_x, 1, 1, self.m)
+            
+    # 단일 행(row)에 대한 내부 세그먼트 트리 구축 (리프 외부 노드)
+    def build_y(self, node_x, row, node_y, start_y, end_y):
+        if start_y == end_y:
+            self.tree[node_x][node_y] = self.leaf_matrix[row][start_y]
+        else:
+            mid = (start_y + end_y) // 2
+            self.build_y(node_x, row, 2*node_y, start_y, mid)
+            self.build_y(node_x, row, 2*node_y+1, mid+1, end_y)
+            self.tree[node_x][node_y] = self.tree[node_x][2*node_y] + self.tree[node_x][2*node_y+1]
+            
+    # 내부 트리 병합: 자식 외부 노드(2*node_x, 2*node_x+1)의 내부 트리 정보를 이용하여 내부 트리 구성
+    def build_y_merge(self, node_x, node_y, start_y, end_y):
+        if start_y == end_y:
+            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
+        else:
+            mid = (start_y + end_y) // 2
+            self.build_y_merge(node_x, 2*node_y, start_y, mid)
+            self.build_y_merge(node_x, 2*node_y+1, mid+1, end_y)
+            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
+            
+    # 2차원 쿼리: 행 구간 [x1, x2]와 열 구간 [y1, y2]의 합 구하기
+    def query_x(self, node_x, start_x, end_x, x1, x2, y1, y2):
+        if x2 < start_x or x1 > end_x:
+            return 0
+        if x1 <= start_x and end_x <= x2:
+            return self.query_y(node_x, 1, 1, self.m, y1, y2)
+        mid = (start_x + end_x) // 2
+        return self.query_x(2*node_x, start_x, mid, x1, x2, y1, y2) + \
+               self.query_x(2*node_x+1, mid+1, end_x, x1, x2, y1, y2)
+    
+    def query_y(self, node_x, node_y, start_y, end_y, y1, y2):
+        if y2 < start_y or y1 > end_y:
+            return 0
+        if y1 <= start_y and end_y <= y2:
+            return self.tree[node_x][node_y]
+        mid = (start_y + end_y) // 2
+        return self.query_y(node_x, 2*node_y, start_y, mid, y1, y2) + \
+               self.query_y(node_x, 2*node_y+1, mid+1, end_y, y1, y2)
+    
+    # 2차원 업데이트: (x, y) 위치의 값을 delta만큼 변경(즉, 기존 값에 delta를 더함)
+    def update_x(self, node_x, start_x, end_x, x, y, delta):
+        if x < start_x or x > end_x:
+            return
+        if start_x == end_x:
+            self.update_y(node_x, 1, 1, self.m, y, delta)
+        else:
+            mid = (start_x + end_x) // 2
+            if x <= mid:
+                self.update_x(2*node_x, start_x, mid, x, y, delta)
+            else:
+                self.update_x(2*node_x+1, mid+1, end_x, x, y, delta)
+            # 자식 외부 노드의 내부 트리 값 변경에 따라 현재 노드의 내부 트리도 갱신
+            self.update_y_merge(node_x, 1, 1, self.m, y)
+    
+    def update_y(self, node_x, node_y, start_y, end_y, y, delta):
+        if y < start_y or y > end_y:
+            return
+        if start_y == end_y:
+            self.tree[node_x][node_y] += delta
+        else:
+            mid = (start_y + end_y) // 2
+            if y <= mid:
+                self.update_y(node_x, 2*node_y, start_y, mid, y, delta)
+            else:
+                self.update_y(node_x, 2*node_y+1, mid+1, end_y, y, delta)
+            self.tree[node_x][node_y] = self.tree[node_x][2*node_y] + self.tree[node_x][2*node_y+1]
+    
+    # 내부 트리 병합 업데이트: 내부 노드에서 y에 해당하는 구간만 갱신
+    def update_y_merge(self, node_x, node_y, start_y, end_y, y):
+        if start_y == end_y:
+            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
+        else:
+            mid = (start_y + end_y) // 2
+            if y <= mid:
+                self.update_y_merge(node_x, 2*node_y, start_y, mid, y)
+            else:
+                self.update_y_merge(node_x, 2*node_y+1, mid+1, end_y, y)
+            self.tree[node_x][node_y] = self.tree[2*node_x][node_y] + self.tree[2*node_x+1][node_y]
+
+
+N, M = map(int, input().split())
+# 1-based로 바꿈
+leaf_matrix = [[0] + list(map(int, input().split())) for _ in range(N)]
+leaf_matrix = [0] + leaf_matrix
+
+tree = SegmentTree2D(leaf_matrix)
+
+for _ in range(M):
+    order = list(map(int, input().split()))
+    w = order[0]
+    if w == 0:
+        x, y, c = order[1], order[2], order[3]
+        # delta = 새 값 - 기존 값
+        delta = c - leaf_matrix[x][y]
+        leaf_matrix[x][y] = c
+        tree.update_x(1, 1, tree.n, x, y, delta)
+    elif w == 1:
+        x1, y1, x2, y2 = order[1], order[2], order[3], order[4]
+        print(tree.query_x(1, 1, tree.n, x1, x2, y1, y2))

--- a/Mar/4week/TaeEun/boj_11659.py
+++ b/Mar/4week/TaeEun/boj_11659.py
@@ -1,0 +1,35 @@
+class FenwickTree:
+    def __init__(self, nodes):
+        self.n = len(nodes)
+        self.tree = [0] * (self.n+1)
+        for i in range(1, self.n+1):
+            self.update(i, nodes[i-1]) 
+            # 0-based를 1-based로 사용
+        
+    def update(self, node, delta):
+        i = node
+        while i <= self.n:
+            self.tree[i] += delta
+            i += i &-i
+            
+    def query(self, node):
+        result = 0
+        i = node
+        while i > 0:
+            result += self.tree[i]
+            i -= i&-i
+        return result
+    # 펜윅의 쿼리는 1~node 까지의 구간합을 반환한다
+    def range_query(self, left, right):
+        return self.query(right) - self.query(left-1)
+
+
+N, M = map(int,input().split())
+
+leaf_nodes = list(map(int,input().split()))
+
+tree = FenwickTree(leaf_nodes)
+
+for _ in range(M):
+    left, right = map(int, input().split())
+    print(tree.range_query(left, right))

--- a/Mar/4week/TaeEun/boj_11660.py
+++ b/Mar/4week/TaeEun/boj_11660.py
@@ -1,0 +1,53 @@
+## 1차원 펜윅부터 구현해서 확장함
+
+
+class FenwickTree2D:
+    def __init__(self, matrix):
+        self.n = len(matrix)
+        self.tree = [[0] * (self.n+1) for _ in range(self.n+1)]
+        for i in range(1, self.n+1):
+            for j in range(1, self.n+1):
+                self.update(i, j, matrix[i-1][j-1]) # 0based를 1based로 사용해야함
+        
+    def update(self, r, c, delta):
+        i = r
+        while i <= self.n:
+            j = c
+            while j <= self.n:
+                self.tree[i][j] += delta
+                j += j&-j
+            i += i &-i
+            
+    def query(self, r, c):
+        res = 0
+        i = r
+        while i > 0:
+            j = c
+            while j> 0:
+                res += self.tree[i][j]
+                j -= j&-j
+            i-= i&-i
+        return res
+    
+    def range_query(self, x1, y1, x2, y2):
+        return self.query(x2, y2) - self.query(x2, y1-1) - self.query(x1-1, y2) + self.query(x1-1, y1-1)       
+
+
+N, M = map(int,input().split())
+
+leaf_matrix = [list(map(int,input().split())) for _ in range(N)]
+
+tree = FenwickTree2D(leaf_matrix)
+
+for _ in range(M):
+    order = list(map(int,input().split()))
+    x1, y1, x2, y2 = order[0], order[1], order[2], order[3]
+    print(tree.range_query(x1, y1, x2, y2))
+        
+        
+        
+        
+        
+        
+        
+

--- a/Mar/4week/TaeEun/boj_13160.py
+++ b/Mar/4week/TaeEun/boj_13160.py
@@ -1,0 +1,45 @@
+
+import heapq
+
+N = int(input())
+edges = []
+
+h = []
+
+for i in range(N):
+    s, e = map(int, input().split())
+    edges.append((s, e))
+    # 시작과 끝을 0과 1로 표현
+    # 좌표가 같을 때 시작 이벤트가 먼저 나오게
+    heapq.heappush(h, (s, 0, i+1))  # i+1은 1based로 변경
+    heapq.heappush(h, (e, 1, i+1))
+
+count = 0      # 현재 겹치는 구간 수
+max_count = 0  # 클리크 크기 최대
+best_coord = 0 # 최대 겹침이 발생한 좌표
+
+# 힙에서 이벤트를 하나씩 꺼내며 선 스위핑
+while h:
+    coord, s_or_e, idx = heapq.heappop(h)
+    
+    if s_or_e == 0:
+        # 시작 이벤트
+        count += 1
+        if count > max_count:
+            max_count = count
+            best_coord = coord
+    else:
+        # 끝 이벤트
+        count -= 1
+
+# best_coord를 포함하는 구간, 즉 최대 클리크를 찾기
+clique = []
+for i, (s, e) in enumerate(edges, start=1):
+    if s <= best_coord <= e:
+        clique.append(i)
+
+clique.sort()
+
+# 결과 출력
+print(max_count)
+print(*clique)

--- a/Mar/4week/TaeEun/boj_2042.py
+++ b/Mar/4week/TaeEun/boj_2042.py
@@ -1,0 +1,71 @@
+class SegmentTreeBottomUp:
+    def __init__(self, leaf_nodes):
+        self.n = len(leaf_nodes)
+        self.tree = [0]*(4*self.n)
+        self.lazy = [0]*(4*self.n)
+        self.build(1, 0, self.n -1) # 최초의 제작
+    
+    def plus(self, a, b):
+        return a+b
+    
+    def build(self, node, start, end):
+        if start == end:
+            self.tree[node] = leaf_nodes[start]
+            return
+        mid = (start+end) // 2
+        self.build(2*node, start, mid)
+        self.build(2*node+1, mid+1, end)
+        self.tree[node] = self.tree[2*node] + self.tree[2*node+1]
+
+    
+    # start, end 는 해당 노드가 감싸고 있는 구간의 양 끝
+    # left, right 는 우리가 검색을 원하는 구간의 양 끝
+    def query(self, node, start, end, left, right):
+        
+        # 우리가 찾는 구간의 오른쪽이, 해당 노드의 왼쪽보다 작으면 노해당
+        # 우리가 찾는 구간의 왼쪽이, 해당 노드의 오른쪽보다 크면 노해당
+        if right < start or left > end:
+            return 0
+        
+        # 해당 노드의 범위가 우리가 찾는 범위의 안쪽이면 그 값으로 돌아가라
+        if right >= end and left <= start:
+            return self.tree[node]
+        
+        mid = (start+end) //2
+        
+        return self.query(2*node, start, mid, left, right) + self.query(2*node+1, mid+1, end, left, right)
+
+    def update_one(self, node, start, end, idx, delta):
+        
+        if idx > end or idx < start:
+            return
+        
+        self.tree[node] += delta
+        
+        if start != end:
+            mid = (start+end)//2
+            self.update_one(2*node, start, mid, idx, delta)
+            self.update_one(2*node+1, mid+1,end, idx, delta)
+
+
+N, M, K = map(int,input().split())
+
+
+leaf_nodes = []
+for _ in range(N):
+    leaf_nodes.append(int(input()))
+tree = SegmentTreeBottomUp(leaf_nodes)
+
+for _ in range(M+K):
+    order = list(map(int,input().split()))
+    a= order[0]
+    # idx화 하려면 -1 해야한다. 번째의 의미
+    b = order[1]-1
+    if a == 1:
+        c = order[2]
+        delta = c-leaf_nodes[b]
+        leaf_nodes[b] = c
+        tree.update_one(1, 0, N-1, b, delta)
+    elif a == 2:
+        c = order[2]-1
+        print(tree.query(1, 0, N-1, b, c))


### PR DESCRIPTION
# 250324

## BOJ.2042.구간 합 구하기

탑 다운 방식으로 다시 구성해봤다.
4*N으로 구성하면 된다는 것도 이해했고
전파하는 과정도 재귀로 구성할 수 있었다.

## BOJ.10999. 구간 합 구하기 2

저번에 했던 바텀 업 방식으로 구성한 늦은 전파(Lazy propagation)는 
보통 구성하는 탑다운 형태로 다시 구성해봤다.
이해하는 데 시간이 많이 걸렸다.
그래도 확실히 이해하긴 했다.
범위를 완전하게 먹은 부분에 대해서만 전파를 진행한다는 이 부분이 중요했던 거 같다.

# 250326
## BOJ.11658.구간 합 구하기 3

아직 제대로 풀지 못했다.
시간초과를 경험했다.
세그먼트 트리를 행렬로 구성해봤는데
처음엔 row를 여러번 도는 걸로 생각했다.
세그먼트 트리를 원소로 하는 행렬에서 인덱스를 활용해 참조하는 걸로 상상했다. 
그렇게 구성하니 바로 시간초과를 경험해서
이번엔 세그먼트 트리를 2중으로 하는 구조를 구성해봤다.
어느정도까진 소화하다가 이것도 시간초과가 났다.
다른 접근방법이 필요해보인다.

# 250327
## BOJ.11658.구간 합 구하기 3
## BOJ.11659.구간 합 구하기 4
## BOJ.11660.구간 합 구하기 5

펜윅 트리로 풀 수 있었다.
기본적인 아이디어는 LSB 즉 처음으로 1이 되는 비트를 구간으로 잡고
해당 비트에서부터 구간까지를 의미하는 것으로 표현했다
구성하는 것은 어렵지 않았고
다만 이해하는 시간이 좀 걸렸다.

# 250328
## BOJ.13160.최대 클리크 구하기
처음에는 아주 단순하게 풀 수 있을 거라 생각했는데
N=300000여서 N^2이 되면 안 되었다.
NlogN을 만드려고 힙을 2개를 사용해서 최소 엔드, 최대 스타트로 관리해보려고 했지만
그것 또한 문제가 발생했다. 아마 뭔가 논리가 뒤틀린 것 보단 다른 이슈 같았는데 찾는데 실패했다.
다행히 선 스위핑이란 개념을 가지고 풀어낼 수 있었다.